### PR TITLE
Migrate crate to Bevy 0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,17 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+## [0.3.0] - 2026-01-20
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-## [0.2.0] - 2025-10-20
-
-### Added
-- Migrated to Bevy 0.17
-- Introduced `EnumEntityEvent` derive macro for entity-targeted events
-- Support for `#[enum_event(target)]` attribute to specify custom target fields
-- Support for `#[enum_event(propagate)]` to enable event propagation up entity hierarchies
-- Support for `#[enum_event(auto_propagate)]` for automatic event propagation
-- Custom propagation relationships via `#[enum_event(propagate = &'static RelType)]`
-- Variant-level propagate attributes that override enum-level settings for fine-grained control
-- Comprehensive documentation for EntityEvent features
-- Integration tests demonstrating observer behavior and event propagation
-- README sections covering `auto_propagate` usage and custom relationship visibility
-
-## [0.1.0] - 2025-10-20
-
-### Added
-- Initial release of `bevy_enum_event` macro
-- Automatic event generation from enum variants
-- Support for unit variants, tuple variants, and named field variants
-- Snake case module generation from enum names
-- Support for generics, lifetimes, and `where` clauses
-- Optional `deref` feature (enabled by default) for ergonomic access to single-field variants
-- `#[enum_event(deref)]` attribute for multi-field variants
-- Automatic `PhantomData` handling for generic unit variants
-- Comprehensive documentation and examples
+### Changed
+- Migrated to Bevy 0.18
 
 ### Features
-- `deref` (default): Automatic `Deref` and `DerefMut` implementation for single-field variants
+- `EnumEvent` derive macro for global events
+- `EnumEntityEvent` derive macro for entity-targeted events
+- `#[enum_event(target)]` for custom target fields
+- `#[enum_event(propagate)]` for event propagation
+- `#[enum_event(auto_propagate)]` for automatic propagation
+- Custom propagation relationships via `#[enum_event(propagate = &'static Type)]`
+- Variant-level attribute overrides
+- `deref` feature (default) for ergonomic field access
+- Full support for generics and lifetimes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,25 @@
 
 ### Changed
 - Migrated to Bevy 0.18
+- Simplified documentation
 
-### Features
-- `EnumEvent` derive macro for global events
+## [0.2.0] - 2025-10-20
+
+### Added
 - `EnumEntityEvent` derive macro for entity-targeted events
 - `#[enum_event(target)]` for custom target fields
 - `#[enum_event(propagate)]` for event propagation
 - `#[enum_event(auto_propagate)]` for automatic propagation
 - Custom propagation relationships via `#[enum_event(propagate = &'static Type)]`
 - Variant-level attribute overrides
+
+### Changed
+- Migrated to Bevy 0.17
+
+## [0.1.0] - 2025-10-20
+
+### Added
+- `EnumEvent` derive macro for global events
+- Support for unit, tuple, and named field variants
 - `deref` feature (default) for ergonomic field access
 - Full support for generics and lifetimes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "assert_type_match"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,27 +84,27 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bevy"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342f7e9335416dc98642d5747c4ed8a6ad9f7244a36d5b2b7a1b7910e4d8f524"
+checksum = "ec689b5a79452b6f777b889bbff22d3216b82a8d2ab7814d4a0eb571e9938d97"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_android"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a9dd9488c77fa2ea31b5da2f978aab7f1cc82e6d2c3be0adf637d9fd7cb6c8"
+checksum = "008133458cfe0d43a8870bfc4c5a729467cc5d9246611462add38bcf45ed896f"
 dependencies = [
  "android-activity",
 ]
 
 [[package]]
 name = "bevy_app"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f582409b4ed3850d9b66ee94e71a0e2c20e7068121d372530060c4dfcba66fa"
+checksum = "2271a0123a7cc355c3fe98754360c75aa84b29f2a6b1a9f8c00aac427570d174"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -115,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c733807158f8fcac68e23222e69ed91a6492ae9410fc2c145b9bb182cfd63e"
+checksum = "70b6a05c31f54c83d681f1b8699bbaf581f06b25a40c9a6bb815625f731f5ba9"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -126,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12fa32312818c08aa4035bebe9fb3f62aaf7efae33688e718dd6ee6c0147493"
+checksum = "aca4caa8a9014a435dca382b1bdebaee4363e9be69882c598fc4ff4d7cd56e6a"
 dependencies = [
  "atomic-waker",
  "bevy_app",
@@ -142,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d929d32190cfcde6efd2df493601c4dbc18a691fd9775a544c951c3c112e1a"
+checksum = "24637a7c8643cab493f4085cda6bde4895f0e0816699c59006f18819da2ca0b8"
 dependencies = [
  "bevy_ecs_macros",
  "bevy_platform",
@@ -168,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eeddfb80a2e000663e87be9229c26b4da92bddbc06c8776bc0d1f4a7f679079"
+checksum = "6eb14c18ca71e11c69fbae873c2db129064efac6d52e48d0127d37bfba1acfa8"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -180,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_enum_event"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bevy",
  "proc-macro2",
@@ -190,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_input"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4074b2d0d6680b4deb308ded7b4e8b1b99181c0502e2632e78af815b26f01"
+checksum = "9c2853993baf27b963a417d3603a73e02e39c5041913cd1ba7211b0a3037b191"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -206,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43985739584f3a5d43026aa1edd772f064830be46c497518f05f7dfbc886bba"
+checksum = "57463815630ea71221c0b8e7bff72d816a3071a89507c45f9e2686fbb5e1956b"
 dependencies = [
  "bevy_android",
  "bevy_app",
@@ -228,11 +234,10 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17dbc3f8948da58b3c17767d20fd3cd35fe4721ed19a9a3204a6f1d6c9951bdd"
+checksum = "0b7272fca0bf30d8ca2571a803598856104b63e5c596d52850f811ed37c5e1e3"
 dependencies = [
- "parking_lot",
  "proc-macro2",
  "quote",
  "syn",
@@ -241,10 +246,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a41e368ffa95ae2a353197d1ae3993f4d3d471444d80b65c932db667ea7b9e"
+checksum = "6a815c514b8a6f7b11508cdc8b3a4bf0761e96a14227af40aa93cb1160989ce0"
 dependencies = [
+ "arrayvec",
  "bevy_reflect",
  "derive_more",
  "glam",
@@ -253,16 +259,15 @@ dependencies = [
  "rand",
  "rand_distr",
  "serde",
- "smallvec",
  "thiserror 2.0.17",
  "variadics_please",
 ]
 
 [[package]]
 name = "bevy_platform"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cf8cda162688c95250e74cffaa1c3a04597f105d4ca35554106f107308ea57"
+checksum = "9b29ea749a8e85f98186ab662f607b885b97c804bb14cdb0cdf838164496d474"
 dependencies = [
  "foldhash",
  "futures-channel",
@@ -275,15 +280,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_ptr"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ab4074e7b781bab84e9b0a41ede245d673d1f75646ce0db27643aedcfb3a85"
+checksum = "4f98cbc6d34bbdb58240b72ed1731931b4991a893b3a3238bb7c42ae054aa676"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333df3f5947b7e62728eb5c0b51d679716b16c7c5283118fed4563f13230954e"
+checksum = "2b2a977e2b8dba65b6e9c11039c5f9ef108be428f036b3d1cac13ad86ec59f9c"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -296,6 +301,7 @@ dependencies = [
  "erased-serde",
  "foldhash",
  "glam",
+ "indexmap",
  "serde",
  "smallvec",
  "thiserror 2.0.17",
@@ -304,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0205dce9c5a4d8d041b263bcfd96e9d9d6f3d49416e12db347ab5778b3071fe1"
+checksum = "067af30072b1611fda1a577f1cb678b8ea2c9226133068be808dd49aac30cef0"
 dependencies = [
  "bevy_macro_utils",
  "indexmap",
@@ -318,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18839182775f30d26f0f84d9de85d25361bb593c99517a80b64ede6cbaf41adc"
+checksum = "990ffedd374dd2c4fe8f0fd4bcefd5617d1ee59164b6c3fcc356a69b48e26e8e"
 dependencies = [
  "async-channel",
  "async-task",
@@ -335,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a52edd3d30ed94074f646ba1c9914e407af9abe5b6fb7a4322c855341a536cc"
+checksum = "e4c68b78e7ca1cc10c811cd1ded8350f53f2be11eb46946879a74c684026bff7"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -348,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7995ae14430b1a268d1e4f098ab770e8af880d2df5e4e37161b47d8d9e9625bd"
+checksum = "b30e3957de42c2f7d88dfe8428e739b74deab8932d2a8bbb9d4eefbd64b6aa34"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -364,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080254083c74d5f6eb0649d7cd6181bda277e8fe3c509ec68990a5d56ec23f24"
+checksum = "e258c44d869f9c41ac0f88a16815c67f2569eb9fff4716828a40273d127b6f84"
 dependencies = [
  "bevy_platform",
  "disqualified",
@@ -634,19 +640,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "equivalent",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
  "hash32",
  "portable-atomic",
@@ -725,15 +732,6 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -819,29 +817,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "pin-project"
@@ -966,15 +941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,12 +954,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -1063,9 +1023,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.107"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_enum_event"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "General-purpose enum to Bevy event conversion macro - generates Event and EntityEvent types from enum variants with support for entity targeting and propagation"
@@ -23,4 +23,4 @@ quote = "1.0"
 proc-macro2 = "1.0"
 
 [dev-dependencies]
-bevy = { version = "0.17", default-features = false }
+bevy = { version = "0.18", default-features = false }

--- a/README.md
+++ b/README.md
@@ -1,139 +1,10 @@
 # bevy_enum_event
 
-General-purpose enum to Bevy event conversion macro.
+Derive macros that generate Bevy event types from enum variants.
 
 ## Overview
 
-`bevy_enum_event` provides derive macros that automatically generate Bevy event types from enum variants. For each variant in your enum, it creates a corresponding event struct organized in a snake_case module. Supports unit variants, tuple variants, and named field variants.
-
-Starting with Bevy 0.17, there are two types of events:
-- **`Event`**: Global events that are not associated with any specific entity
-- **`EntityEvent`**: Events that target a specific entity and can trigger entity-specific observers
-
-This crate provides corresponding derive macros for both:
-- `#[derive(EnumEvent)]` - Generates `Event` types
-- `#[derive(EnumEntityEvent)]` - Generates `EntityEvent` types
-
-## Bevy Compatibility
-
-|  Bevy   | bevy_enum_event |
-|---------|-----------------|
-| 0.17    | 0.2             |
-| 0.16    | 0.1             |
-
-## Features
-
-- **Automatic event generation**: One macro generates all variant events
-- **Support for data-carrying variants**: Enum variants can contain data (tuple or named fields)
-- **Snake case module**: `PlayerState` → `player_state` module
-- **Zero boilerplate**: No manual event struct definitions needed
-- **Type-safe**: Each variant gets its own distinct event type
-- **Generic-friendly**: Works with lifetimes, generic parameters, and `where` clauses
-- **Bevy integration**: Generated events work seamlessly with Bevy's observer system
-- **Entity event support**: Generate `EntityEvent` types with entity targeting and propagation
-- **Deref support** (optional, enabled by default): Automatic `Deref` and `DerefMut` for ergonomic field access
-
-## Installation
-
-```toml
-[dependencies]
-bevy_enum_event = "0.2"
-```
-
----
-
-# Part 1: EnumEvent - Global Events
-
-## Quick Start - Unit Variants
-
-```rust
-use bevy::prelude::*;
-use bevy_enum_event::EnumEvent;
-
-#[derive(EnumEvent, Clone, Copy, Debug)]
-enum PlayerState {
-    Idle,
-    Running,
-    Jumping,
-}
-```
-
-This automatically generates:
-
-```rust
-pub mod player_state {
-    use bevy::prelude::Event;
-
-    #[derive(Event, Clone, Copy, Debug)]
-    pub struct Idle;
-
-    #[derive(Event, Clone, Copy, Debug)]
-    pub struct Running;
-
-    #[derive(Event, Clone, Copy, Debug)]
-    pub struct Jumping;
-}
-```
-
-## Variants with Data
-
-Enum variants can carry data using tuple or named field syntax:
-
-```rust
-use bevy::prelude::*;
-use bevy_enum_event::EnumEvent;
-
-#[derive(EnumEvent, Clone)]
-enum GameEvent {
-    PlayerSpawned(Entity),
-    ScoreChanged { player: Entity, score: i32 },
-    GameOver,
-}
-```
-
-This generates:
-
-```rust
-pub mod game_event {
-    use bevy::prelude::Event;
-
-    #[derive(Event, Clone, Debug)]
-    pub struct PlayerSpawned(pub Entity);
-
-    #[derive(Event, Clone, Debug)]
-    pub struct ScoreChanged {
-        pub player: Entity,
-        pub score: i32,
-    }
-
-    #[derive(Event, Clone, Debug)]
-    pub struct GameOver;
-}
-```
-
-## Using Events with Bevy Observers
-
-```rust
-use bevy::prelude::*;
-use bevy_enum_event::EnumEvent;
-
-#[derive(EnumEvent, Clone, Copy)]
-enum GameState {
-    MainMenu,
-    Playing,
-    Paused,
-}
-
-fn setup(app: &mut App) {
-    app.observe(on_paused);
-}
-
-fn on_paused(paused: On<game_state::Paused>) {
-    println!("Game paused!");
-}
-```
-
-### Accessing Event Data
+Transform enum variants into distinct Bevy event structs automatically. Each variant becomes a separate event type in a snake_case module, eliminating boilerplate while preserving type safety.
 
 ```rust
 use bevy::prelude::*;
@@ -146,163 +17,114 @@ enum GameEvent {
     GameOver,
 }
 
-fn on_score_changed(score: On<game_event::ScoreChanged>) {
-    let event = score.event();
-    println!("Team {} scored {} points", event.team, event.score);
-}
+// Generates: game_event::Victory, game_event::ScoreChanged, game_event::GameOver
 ```
 
-## Deref Feature (enabled by default)
+## Bevy Compatibility
 
-The `deref` feature provides ergonomic access to event data by automatically implementing `Deref` and `DerefMut`:
+| Bevy | bevy_enum_event |
+|------|-----------------|
+| 0.18 | 0.3             |
 
-- **Single-field variants**: Automatically get deref to the inner value
-- **Multi-field variants**: Mark one field with `#[enum_event(deref)]` for deref access
-- **No annotation**: Access fields directly by name
-
-### Example - Automatic Deref
-
-```rust
-use bevy::prelude::*;
-use bevy_enum_event::EnumEvent;
-
-#[derive(EnumEvent, Clone)]
-enum NetworkEvent {
-    MessageReceived(String),      // Single field - automatic deref
-    HealthChanged { value: f32 },  // Single field - automatic deref
-}
-
-fn on_message(msg: On<network_event::MessageReceived>) {
-    // Direct access to the String via deref
-    let content: &String = &*msg.event();
-    println!("Received: {}", content);
-}
-
-fn on_health(health: On<network_event::HealthChanged>) {
-    // Direct access to the f32 via deref
-    let value: f32 = *health.event();
-    println!("Health: {}", value);
-}
-```
-
-### Example - Multi-Field with Deref Annotation
-
-```rust
-use bevy::prelude::*;
-use bevy_enum_event::EnumEvent;
-
-#[derive(EnumEvent, Clone)]
-enum GameEvent {
-    // Mark the primary field for deref access
-    PlayerScored { #[enum_event(deref)] player: Entity, points: u32 },
-
-    // No annotation - access fields directly
-    TeamScore { team: u32, points: u32 },
-}
-
-fn on_player_scored(scored: On<game_event::PlayerScored>) {
-    // Deref gives you the player entity
-    let player: Entity = *scored.event();
-    // Other fields still accessible by name
-    println!("Player {:?} scored {} points", player, scored.event().points);
-}
-
-fn on_team_score(scored: On<game_event::TeamScore>) {
-    // No deref - access fields directly
-    let event = scored.event();
-    println!("Team {} scored {} points", event.team, event.points);
-}
-```
-
-### Disabling Deref
-
-If you prefer not to have `Deref` and `DerefMut` automatically implemented:
+## Installation
 
 ```toml
 [dependencies]
-bevy_enum_event = { version = "0.2", default-features = false }
+bevy_enum_event = "0.3"
 ```
 
-When disabled, access fields directly:
+## Macros
+
+- **`EnumEvent`** - Generates global `Event` types
+- **`EnumEntityEvent`** - Generates entity-targeted `EntityEvent` types with optional propagation
+
+## EnumEvent
+
+Supports unit, tuple, and named field variants:
 
 ```rust
-fn on_message(msg: On<network_event::MessageReceived>) {
-    let content: &String = &msg.event().0;  // Access via .0 for tuple variants
-    println!("Received: {}", content);
+use bevy_enum_event::EnumEvent;
+
+#[derive(EnumEvent, Clone)]
+enum PlayerState {
+    Idle,                           // Unit variant
+    Moving(f32),                    // Tuple variant
+    Attacking { target: Entity },   // Named field variant
 }
 ```
 
-## Advanced: Generics & Lifetimes
+### Using with Observers
 
-The macro preserves generic parameters, lifetimes, and `where` clauses from your enum:
+```rust
+fn setup(app: &mut App) {
+    app.observe(on_attacking);
+}
+
+fn on_attacking(event: On<player_state::Attacking>) {
+    println!("Attacking {:?}", event.event().target);
+}
+```
+
+### Deref Feature (default)
+
+Single-field variants automatically implement `Deref`/`DerefMut`:
 
 ```rust
 #[derive(EnumEvent, Clone)]
-enum GenericEvent<'a, T>
-where
-    T: Clone + 'a,
-{
-    Borrowed(&'a T),
-    Owned(T),
-    Done,
+enum NetworkEvent {
+    MessageReceived(String),  // Automatic deref to String
+}
+
+fn on_message(msg: On<network_event::MessageReceived>) {
+    let content: &String = &*msg.event();
 }
 ```
 
-Generated types: `generic_event::Borrowed<'a, T>`, `generic_event::Owned<'a, T>`, `generic_event::Done<'a, T>`.
+For multi-field variants, mark one field with `#[enum_event(deref)]`:
 
-Unit variants automatically implement `Default` and get a `new()` helper when phantom markers are needed. Tuple and named variants with phantom markers also receive `new(...)` helpers that accept only the original fields.
+```rust
+#[derive(EnumEvent, Clone)]
+enum GameEvent {
+    PlayerScored {
+        #[enum_event(deref)]
+        player: Entity,
+        points: u32
+    },
+}
+```
 
----
+Disable with `default-features = false`.
 
-# Part 2: EnumEntityEvent - Entity-Targeted Events
+## EnumEntityEvent
 
-`EntityEvent` types target specific entities and can trigger entity-specific observers, enabling fine-grained control over event handling.
+Entity-targeted events that trigger entity-specific observers.
 
-## Important Requirements
+### Requirements
 
-Before diving into examples, note these requirements for `EnumEntityEvent`:
-
-- **Named fields only**: All variants must use struct-style `{ field: Type }` syntax
-- **Entity field required**: Each variant must have either:
-  - A field named `entity: Entity`, OR
-  - A field marked with `#[enum_event(target)]`
-- **Triggering**: Use `commands.trigger(event)` or `world.trigger(event)`
-
-## Basic EntityEvent Usage
+- Named fields only (`{ field: Type }` syntax)
+- Must have `entity: Entity` field or `#[enum_event(target)]` on a custom field
 
 ```rust
 use bevy::prelude::*;
 use bevy_enum_event::EnumEntityEvent;
 
-#[derive(EnumEntityEvent, Clone)]
+#[derive(EnumEntityEvent, Clone, Copy)]
 enum PlayerEvent {
     Spawned { entity: Entity },
     Damaged { entity: Entity, amount: f32 },
-    Destroyed { entity: Entity },
 }
 
-// Global observer - runs for ALL player damage events
-fn on_any_player_damaged(damaged: On<player_event::Damaged>) {
-    println!("A player took {} damage", damaged.amount);
-}
-
-// Entity-specific observer - only runs for events targeting this specific entity
-fn setup_player(mut commands: Commands) {
-    commands.spawn_empty()
-        .observe(|damaged: On<player_event::Damaged>| {
-            println!("This specific player took {} damage", damaged.amount);
-        });
+// Entity-specific observer
+fn setup(mut commands: Commands) {
+    commands.spawn_empty().observe(|damaged: On<player_event::Damaged>| {
+        println!("This player took {} damage", damaged.amount);
+    });
 }
 ```
 
-## Custom Target Field
-
-By default, `EnumEntityEvent` looks for a field named `entity`. You can use a different field with `#[enum_event(target)]`:
+### Custom Target Field
 
 ```rust
-use bevy::prelude::*;
-use bevy_enum_event::EnumEntityEvent;
-
 #[derive(EnumEntityEvent, Clone, Copy)]
 enum CombatEvent {
     Attack {
@@ -311,113 +133,62 @@ enum CombatEvent {
         defender: Entity,
     },
 }
-
-// This event will trigger observers on the attacker entity
-fn trigger_attack(mut commands: Commands, attacker: Entity, defender: Entity) {
-    commands.trigger(combat_event::Attack { attacker, defender });
-}
 ```
 
-## Event Propagation
+### Event Propagation
 
-Event propagation allows events to "bubble up" through entity hierarchies, similar to DOM event propagation in web browsers.
-
-### Basic Propagation
-
-Enable propagation with `#[enum_event(propagate)]`:
+Events can bubble up entity hierarchies:
 
 ```rust
-use bevy::prelude::*;
-use bevy_enum_event::EnumEntityEvent;
-
-// Default propagation uses the ChildOf relationship
+// Basic propagation (uses ChildOf)
 #[derive(EnumEntityEvent, Clone, Copy)]
 #[enum_event(propagate)]
 enum UiEvent {
     Click { entity: Entity },
-    Hover { entity: Entity },
 }
 
-fn on_click(mut click: On<ui_event::Click>) {
-    println!("Clicked on: {:?}", click.entity);
-
-    // Cause the event to bubbling up to parent entities
-    click.propagate(true);
-
-    // Access the original target that triggered the event
-    let original = click.original_event_target();
-}
-```
-
-### Auto Propagation
-
-For events that should always bubble up without manual control:
-
-```rust
+// Auto propagation (always bubbles)
 #[derive(EnumEntityEvent, Clone, Copy)]
 #[enum_event(auto_propagate, propagate)]
 enum SystemEvent {
     Update { entity: Entity },
 }
-```
 
-### Custom Propagation Relationships
-
-Specify a custom relationship type for propagation instead of the default `ChildOf`:
-
-```rust
-use bevy::prelude::*;
-use bevy_enum_event::EnumEntityEvent;
-
-#[derive(Component)]
-#[relationship(relationship_target = CustomRelationshipTarget)]
-pub struct CustomRelationship(pub Entity);
-
-#[derive(Component)]
-#[relationship_target(relationship = CustomRelationship, linked_spawn)]
-pub struct CustomRelationshipTarget(Vec<Entity>);
-
-// Propagate along CustomRelationship instead of ChildOf
-// Note: Use absolute paths (::) or make the relationship public
+// Custom relationship
 #[derive(EnumEntityEvent, Clone, Copy)]
-#[enum_event(propagate = &'static CustomRelationship)]
-enum NetworkEvent {
-    DataReceived { entity: Entity },
+#[enum_event(propagate = &'static ::bevy::prelude::ChildOf)]
+enum CustomEvent {
+    Action { entity: Entity },
 }
 ```
 
-**Important**: Custom relationship types must be `pub` or referenced via absolute paths (`::bevy::`, `crate::`, etc.) because they're accessed from the generated module.
+Control propagation in observers:
 
-### Variant-Level Propagation
+```rust
+fn on_click(mut click: On<ui_event::Click>) {
+    click.propagate(true);  // Continue bubbling
+    let original = click.original_event_target();
+}
+```
 
-Override enum-level propagation settings for specific variants:
+### Variant-Level Overrides
+
+Override enum-level settings per variant:
 
 ```rust
 #[derive(EnumEntityEvent, Clone, Copy)]
-#[enum_event(propagate)]  // Default for all variants
+#[enum_event(propagate)]
 enum MixedEvent {
-    Normal { entity: Entity },  // Uses enum-level propagate
+    Normal { entity: Entity },  // Uses enum-level
 
-    #[enum_event(auto_propagate, propagate)]  // Override with auto_propagate
-    AutoEvent { entity: Entity },
-
-    #[enum_event(propagate = &'static ::bevy::prelude::ChildOf)]  // Custom relationship
-    CustomEvent { entity: Entity },
+    #[enum_event(auto_propagate, propagate)]
+    AutoEvent { entity: Entity },  // Overrides with auto
 }
-
-## Snake Case Conversion
-
-The macro intelligently converts enum names to snake_case module names:
-
-- `LifeFSM` → `life_fsm`
-- `PlayerState` → `player_state`
-- `HTTPServer` → `http_server`
-- `MyHTTPSConnection` → `my_https_connection`
+```
 
 ## Generics & Lifetimes
 
-All derives mirror the generic parameters, lifetimes, and `where` clauses from your enum onto the generated
-event structs. This makes it straightforward to use `EnumEvent` with enums such as:
+Full support for generic parameters and lifetimes:
 
 ```rust
 #[derive(EnumEvent, Clone)]
@@ -431,41 +202,6 @@ where
 }
 ```
 
-The generated module exposes `generic_event::Borrowed<'a, T>`, `generic_event::Owned<'a, T>`, and
-`generic_event::Done<'a, T>` types with identical bounds.
-
-Unit event structs expose ergonomic constructors so you never have to juggle hidden `PhantomData`
-markers by hand. Every unit variant implements `Default`, and when a phantom marker is required the
-derive also emits a `new()` helper that seeds it for you. Tuple and named variants that require
-phantom markers likewise receive `new(...)` helpers that accept only the original fields.
-
-## Use Cases
-
-- State machines (see [bevy_fsm](https://crates.io/crates/bevy_fsm))
-- Game state transitions
-- Entity lifecycle events
-- Animation states
-- Input modes
-- Any enum-based event system
-- Network message events
-- Input/Output events with associated data
-
-## AI Disclaimer
-
-- Refactoring and documentation supported by Claude Code
-- Minor editing supported by ChatGPT Codex
-- The process and final releases are thoroughly supervised and checked by the author
-
 ## License
 
-Licensed under either of:
-
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
-
-at your option.
-
-### Contribution
-
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
-
+MIT OR Apache-2.0

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ enum GameEvent {
 | Bevy | bevy_enum_event |
 |------|-----------------|
 | 0.18 | 0.3             |
+| 0.17 | 0.2             |
+| 0.16 | 0.1             |
 
 ## Installation
 

--- a/tests/check_override.rs
+++ b/tests/check_override.rs
@@ -7,15 +7,21 @@ use bevy_enum_event::EnumEntityEvent;
 #[allow(dead_code)]
 enum AutoPropagateOverrideEvent {
     // Inherits: auto_propagate, propagate
-    InheritAuto { entity: Entity },
+    InheritAuto {
+        entity: Entity,
+    },
 
     // Override: removes auto_propagate, uses custom relation
     #[enum_event(propagate = &'static ::bevy::prelude::ChildOf)]
-    NoAutoCustomRel { entity: Entity },
+    NoAutoCustomRel {
+        entity: Entity,
+    },
 
     // Override: keeps auto_propagate, uses custom relation
     #[enum_event(auto_propagate, propagate = &'static ::bevy::prelude::ChildOf)]
-    WithAutoCustomRel { entity: Entity },
+    WithAutoCustomRel {
+        entity: Entity,
+    },
 }
 
 // Compile test - if this compiles, it means the attributes are correctly applied

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -414,7 +414,6 @@ pub struct ArmorOf(Entity);
 #[relationship_target(relationship = ArmorOf)]
 pub struct ArmorParts(Vec<Entity>);
 
-
 #[derive(EnumEntityEvent, Clone, Copy)]
 #[enum_event(auto_propagate, propagate =  &'static crate::ArmorOf)]
 #[allow(dead_code)]
@@ -429,10 +428,7 @@ fn test_armor_goblin_propagation_custom() {
 
     // Spawn parent (goblin) with child (armor) to establish ChildOf relationship
     let goblin_id = app.world_mut().spawn(HitPoints(50)).id();
-    let armor_id = app
-        .world_mut()
-        .spawn((Armor(10), ArmorOf(goblin_id)))
-        .id();
+    let armor_id = app.world_mut().spawn((Armor(10), ArmorOf(goblin_id))).id();
 
     // Add observer on goblin - takes damage if attack gets through armor
     app.world_mut().entity_mut(goblin_id).observe(
@@ -529,19 +525,31 @@ pub struct ShieldedBy(Vec<Entity>);
 #[allow(dead_code)]
 enum VariantLevelPropagateEvent {
     // Variant A: No propagation (baseline - should not propagate)
-    NoPropagation { entity: Entity, damage: u16 },
+    NoPropagation {
+        entity: Entity,
+        damage: u16,
+    },
 
     // Variant B: Basic propagate with default relationship (manual control)
     #[enum_event(propagate)]
-    BasicPropagate { entity: Entity, damage: u16 },
+    BasicPropagate {
+        entity: Entity,
+        damage: u16,
+    },
 
     // Variant C: Auto-propagate with default relationship (ChildOf)
     #[enum_event(auto_propagate, propagate)]
-    AutoPropagate { entity: Entity, damage: u16 },
+    AutoPropagate {
+        entity: Entity,
+        damage: u16,
+    },
 
     // Variant D: Auto-propagate with custom relationship (ShieldOf)
     #[enum_event(auto_propagate, propagate = &'static crate::ShieldOf)]
-    AutoPropagateCustom { entity: Entity, damage: u16 },
+    AutoPropagateCustom {
+        entity: Entity,
+        damage: u16,
+    },
 }
 
 #[test]
@@ -552,15 +560,22 @@ fn test_scenario1_no_enum_propagation_variant_definitions() {
 
     // Setup hierarchy: Parent <- Child (using ChildOf)
     let parent = app.world_mut().spawn(DamageLog(vec![])).id();
-    let child = app.world_mut().spawn((DamageLog(vec![]), ChildOf(parent))).id();
+    let child = app
+        .world_mut()
+        .spawn((DamageLog(vec![]), ChildOf(parent)))
+        .id();
 
     // Setup hierarchy with custom relationship: Protected <- Shield (using ShieldOf)
     let protected = app.world_mut().spawn(DamageLog(vec![])).id();
-    let shield = app.world_mut().spawn((DamageLog(vec![]), ShieldOf(protected))).id();
+    let shield = app
+        .world_mut()
+        .spawn((DamageLog(vec![]), ShieldOf(protected)))
+        .id();
 
     // Add observers on parents
     app.world_mut().entity_mut(parent).observe(
-        |event: On<variant_level_propagate_event::NoPropagation>, mut query: Query<&mut DamageLog>| {
+        |event: On<variant_level_propagate_event::NoPropagation>,
+         mut query: Query<&mut DamageLog>| {
             if let Ok(mut log) = query.get_mut(event.entity) {
                 log.0.push(format!("parent_no_prop_{}", event.damage));
             }
@@ -568,7 +583,8 @@ fn test_scenario1_no_enum_propagation_variant_definitions() {
     );
 
     app.world_mut().entity_mut(parent).observe(
-        |event: On<variant_level_propagate_event::BasicPropagate>, mut query: Query<&mut DamageLog>| {
+        |event: On<variant_level_propagate_event::BasicPropagate>,
+         mut query: Query<&mut DamageLog>| {
             if let Ok(mut log) = query.get_mut(event.entity) {
                 log.0.push(format!("parent_basic_{}", event.damage));
             }
@@ -576,7 +592,8 @@ fn test_scenario1_no_enum_propagation_variant_definitions() {
     );
 
     app.world_mut().entity_mut(parent).observe(
-        |event: On<variant_level_propagate_event::AutoPropagate>, mut query: Query<&mut DamageLog>| {
+        |event: On<variant_level_propagate_event::AutoPropagate>,
+         mut query: Query<&mut DamageLog>| {
             if let Ok(mut log) = query.get_mut(event.entity) {
                 log.0.push(format!("parent_auto_{}", event.damage));
             }
@@ -584,16 +601,19 @@ fn test_scenario1_no_enum_propagation_variant_definitions() {
     );
 
     app.world_mut().entity_mut(protected).observe(
-        |event: On<variant_level_propagate_event::AutoPropagateCustom>, mut query: Query<&mut DamageLog>| {
+        |event: On<variant_level_propagate_event::AutoPropagateCustom>,
+         mut query: Query<&mut DamageLog>| {
             if let Ok(mut log) = query.get_mut(event.entity) {
-                log.0.push(format!("protected_auto_custom_{}", event.damage));
+                log.0
+                    .push(format!("protected_auto_custom_{}", event.damage));
             }
         },
     );
 
     // Add observers on children
     app.world_mut().entity_mut(child).observe(
-        |event: On<variant_level_propagate_event::NoPropagation>, mut query: Query<&mut DamageLog>| {
+        |event: On<variant_level_propagate_event::NoPropagation>,
+         mut query: Query<&mut DamageLog>| {
             if let Ok(mut log) = query.get_mut(event.entity) {
                 log.0.push(format!("child_no_prop_{}", event.damage));
             }
@@ -601,7 +621,8 @@ fn test_scenario1_no_enum_propagation_variant_definitions() {
     );
 
     app.world_mut().entity_mut(child).observe(
-        |mut event: On<variant_level_propagate_event::BasicPropagate>, mut query: Query<&mut DamageLog>| {
+        |mut event: On<variant_level_propagate_event::BasicPropagate>,
+         mut query: Query<&mut DamageLog>| {
             if let Ok(mut log) = query.get_mut(event.entity) {
                 log.0.push(format!("child_basic_{}", event.damage));
                 // Manually enable propagation for this test
@@ -611,7 +632,8 @@ fn test_scenario1_no_enum_propagation_variant_definitions() {
     );
 
     app.world_mut().entity_mut(child).observe(
-        |event: On<variant_level_propagate_event::AutoPropagate>, mut query: Query<&mut DamageLog>| {
+        |event: On<variant_level_propagate_event::AutoPropagate>,
+         mut query: Query<&mut DamageLog>| {
             if let Ok(mut log) = query.get_mut(event.entity) {
                 log.0.push(format!("child_auto_{}", event.damage));
                 // Auto-propagate is implicit - no need to call propagate(true)
@@ -620,7 +642,8 @@ fn test_scenario1_no_enum_propagation_variant_definitions() {
     );
 
     app.world_mut().entity_mut(shield).observe(
-        |event: On<variant_level_propagate_event::AutoPropagateCustom>, mut query: Query<&mut DamageLog>| {
+        |event: On<variant_level_propagate_event::AutoPropagateCustom>,
+         mut query: Query<&mut DamageLog>| {
             if let Ok(mut log) = query.get_mut(event.entity) {
                 log.0.push(format!("shield_auto_custom_{}", event.damage));
                 // Auto-propagate is implicit with custom relationship
@@ -631,24 +654,34 @@ fn test_scenario1_no_enum_propagation_variant_definitions() {
     app.update();
 
     // Test Variant A: NoPropagation - should NOT propagate to parent
-    app.world_mut().trigger(variant_level_propagate_event::NoPropagation {
-        entity: child,
-        damage: 10,
-    });
+    app.world_mut()
+        .trigger(variant_level_propagate_event::NoPropagation {
+            entity: child,
+            damage: 10,
+        });
     app.update();
 
     let child_log = app.world().get::<DamageLog>(child).unwrap();
-    assert_eq!(child_log.0.len(), 1, "Child should have received NoPropagation event");
+    assert_eq!(
+        child_log.0.len(),
+        1,
+        "Child should have received NoPropagation event"
+    );
     assert_eq!(child_log.0[0], "child_no_prop_10");
 
     let parent_log = app.world().get::<DamageLog>(parent).unwrap();
-    assert_eq!(parent_log.0.len(), 0, "Parent should NOT receive NoPropagation event (no propagation)");
+    assert_eq!(
+        parent_log.0.len(),
+        0,
+        "Parent should NOT receive NoPropagation event (no propagation)"
+    );
 
     // Test Variant B: BasicPropagate - should propagate when manually enabled
-    app.world_mut().trigger(variant_level_propagate_event::BasicPropagate {
-        entity: child,
-        damage: 20,
-    });
+    app.world_mut()
+        .trigger(variant_level_propagate_event::BasicPropagate {
+            entity: child,
+            damage: 20,
+        });
     app.update();
 
     let child_log = app.world().get::<DamageLog>(child).unwrap();
@@ -656,14 +689,19 @@ fn test_scenario1_no_enum_propagation_variant_definitions() {
     assert_eq!(child_log.0[1], "child_basic_20");
 
     let parent_log = app.world().get::<DamageLog>(parent).unwrap();
-    assert_eq!(parent_log.0.len(), 1, "Parent should receive BasicPropagate event (manual propagation)");
+    assert_eq!(
+        parent_log.0.len(),
+        1,
+        "Parent should receive BasicPropagate event (manual propagation)"
+    );
     assert_eq!(parent_log.0[0], "parent_basic_20");
 
     // Test Variant C: AutoPropagate - should auto-propagate with ChildOf
-    app.world_mut().trigger(variant_level_propagate_event::AutoPropagate {
-        entity: child,
-        damage: 30,
-    });
+    app.world_mut()
+        .trigger(variant_level_propagate_event::AutoPropagate {
+            entity: child,
+            damage: 30,
+        });
     app.update();
 
     let child_log = app.world().get::<DamageLog>(child).unwrap();
@@ -671,14 +709,19 @@ fn test_scenario1_no_enum_propagation_variant_definitions() {
     assert_eq!(child_log.0[2], "child_auto_30");
 
     let parent_log = app.world().get::<DamageLog>(parent).unwrap();
-    assert_eq!(parent_log.0.len(), 2, "Parent should receive AutoPropagate event (auto-propagation)");
+    assert_eq!(
+        parent_log.0.len(),
+        2,
+        "Parent should receive AutoPropagate event (auto-propagation)"
+    );
     assert_eq!(parent_log.0[1], "parent_auto_30");
 
     // Test Variant D: AutoPropagateCustom - should auto-propagate with ShieldOf
-    app.world_mut().trigger(variant_level_propagate_event::AutoPropagateCustom {
-        entity: shield,
-        damage: 40,
-    });
+    app.world_mut()
+        .trigger(variant_level_propagate_event::AutoPropagateCustom {
+            entity: shield,
+            damage: 40,
+        });
     app.update();
 
     let shield_log = app.world().get::<DamageLog>(shield).unwrap();
@@ -686,7 +729,11 @@ fn test_scenario1_no_enum_propagation_variant_definitions() {
     assert_eq!(shield_log.0[0], "shield_auto_custom_40");
 
     let protected_log = app.world().get::<DamageLog>(protected).unwrap();
-    assert_eq!(protected_log.0.len(), 1, "Protected should receive event (auto-propagate with custom relationship)");
+    assert_eq!(
+        protected_log.0.len(),
+        1,
+        "Protected should receive event (auto-propagate with custom relationship)"
+    );
     assert_eq!(protected_log.0[0], "protected_auto_custom_40");
 }
 
@@ -710,23 +757,38 @@ pub struct MountedBy(Vec<Entity>);
 #[allow(dead_code)]
 enum EnumLevelPropagateEvent {
     // Variant A: No override - inherits enum-level (auto_propagate + ChildOf)
-    InheritEnum { entity: Entity, value: u16 },
+    InheritEnum {
+        entity: Entity,
+        value: u16,
+    },
 
     // Variant B: Override with manual propagate + default relationship
     #[enum_event(propagate)]
-    ManualDefault { entity: Entity, value: u16 },
+    ManualDefault {
+        entity: Entity,
+        value: u16,
+    },
 
     // Variant C: Override with auto_propagate + default relationship
     #[enum_event(auto_propagate, propagate)]
-    AutoDefault { entity: Entity, value: u16 },
+    AutoDefault {
+        entity: Entity,
+        value: u16,
+    },
 
     // Variant D: Override with manual propagate + custom relationship (MountOf)
     #[enum_event(propagate = &'static crate::MountOf)]
-    ManualCustom { entity: Entity, value: u16 },
+    ManualCustom {
+        entity: Entity,
+        value: u16,
+    },
 
     // Variant E: Override with auto_propagate + custom relationship (MountOf)
     #[enum_event(auto_propagate, propagate = &'static crate::MountOf)]
-    AutoCustom { entity: Entity, value: u16 },
+    AutoCustom {
+        entity: Entity,
+        value: u16,
+    },
 }
 
 #[test]
@@ -737,11 +799,17 @@ fn test_scenario2_enum_propagation_with_variant_overrides() {
 
     // Setup hierarchy with ChildOf relationship: Parent <- Child
     let parent_child = app.world_mut().spawn(DamageLog(vec![])).id();
-    let child_child = app.world_mut().spawn((DamageLog(vec![]), ChildOf(parent_child))).id();
+    let child_child = app
+        .world_mut()
+        .spawn((DamageLog(vec![]), ChildOf(parent_child)))
+        .id();
 
     // Setup hierarchy with MountOf relationship: Rider <- Mount
     let rider = app.world_mut().spawn(DamageLog(vec![])).id();
-    let mount = app.world_mut().spawn((DamageLog(vec![]), MountOf(rider))).id();
+    let mount = app
+        .world_mut()
+        .spawn((DamageLog(vec![]), MountOf(rider)))
+        .id();
 
     // === Variant A: InheritEnum (inherits auto_propagate + ChildOf) ===
     app.world_mut().entity_mut(parent_child).observe(
@@ -771,7 +839,8 @@ fn test_scenario2_enum_propagation_with_variant_overrides() {
     );
 
     app.world_mut().entity_mut(child_child).observe(
-        |mut event: On<enum_level_propagate_event::ManualDefault>, mut query: Query<&mut DamageLog>| {
+        |mut event: On<enum_level_propagate_event::ManualDefault>,
+         mut query: Query<&mut DamageLog>| {
             if let Ok(mut log) = query.get_mut(event.entity) {
                 log.0.push(format!("child_manual_def_{}", event.value));
                 // Manual propagate - must explicitly enable
@@ -808,7 +877,8 @@ fn test_scenario2_enum_propagation_with_variant_overrides() {
     );
 
     app.world_mut().entity_mut(mount).observe(
-        |mut event: On<enum_level_propagate_event::ManualCustom>, mut query: Query<&mut DamageLog>| {
+        |mut event: On<enum_level_propagate_event::ManualCustom>,
+         mut query: Query<&mut DamageLog>| {
             if let Ok(mut log) = query.get_mut(event.entity) {
                 log.0.push(format!("mount_manual_custom_{}", event.value));
                 // Manual propagate with custom relationship
@@ -839,10 +909,11 @@ fn test_scenario2_enum_propagation_with_variant_overrides() {
 
     // === Test Variant A: InheritEnum ===
     // Should inherit enum-level: auto_propagate + ChildOf
-    app.world_mut().trigger(enum_level_propagate_event::InheritEnum {
-        entity: child_child,
-        value: 10,
-    });
+    app.world_mut()
+        .trigger(enum_level_propagate_event::InheritEnum {
+            entity: child_child,
+            value: 10,
+        });
     app.update();
 
     let child_log = app.world().get::<DamageLog>(child_child).unwrap();
@@ -850,15 +921,20 @@ fn test_scenario2_enum_propagation_with_variant_overrides() {
     assert_eq!(child_log.0[0], "child_inherit_10");
 
     let parent_log = app.world().get::<DamageLog>(parent_child).unwrap();
-    assert_eq!(parent_log.0.len(), 1, "Parent should receive InheritEnum (inherited auto_propagate)");
+    assert_eq!(
+        parent_log.0.len(),
+        1,
+        "Parent should receive InheritEnum (inherited auto_propagate)"
+    );
     assert_eq!(parent_log.0[0], "parent_inherit_10");
 
     // === Test Variant B: ManualDefault ===
     // Override: manual propagate + default ChildOf
-    app.world_mut().trigger(enum_level_propagate_event::ManualDefault {
-        entity: child_child,
-        value: 20,
-    });
+    app.world_mut()
+        .trigger(enum_level_propagate_event::ManualDefault {
+            entity: child_child,
+            value: 20,
+        });
     app.update();
 
     let child_log = app.world().get::<DamageLog>(child_child).unwrap();
@@ -866,15 +942,20 @@ fn test_scenario2_enum_propagation_with_variant_overrides() {
     assert_eq!(child_log.0[1], "child_manual_def_20");
 
     let parent_log = app.world().get::<DamageLog>(parent_child).unwrap();
-    assert_eq!(parent_log.0.len(), 2, "Parent should receive ManualDefault (manual propagate called)");
+    assert_eq!(
+        parent_log.0.len(),
+        2,
+        "Parent should receive ManualDefault (manual propagate called)"
+    );
     assert_eq!(parent_log.0[1], "parent_manual_def_20");
 
     // === Test Variant C: AutoDefault ===
     // Override: auto_propagate + default ChildOf
-    app.world_mut().trigger(enum_level_propagate_event::AutoDefault {
-        entity: child_child,
-        value: 30,
-    });
+    app.world_mut()
+        .trigger(enum_level_propagate_event::AutoDefault {
+            entity: child_child,
+            value: 30,
+        });
     app.update();
 
     let child_log = app.world().get::<DamageLog>(child_child).unwrap();
@@ -882,15 +963,20 @@ fn test_scenario2_enum_propagation_with_variant_overrides() {
     assert_eq!(child_log.0[2], "child_auto_def_30");
 
     let parent_log = app.world().get::<DamageLog>(parent_child).unwrap();
-    assert_eq!(parent_log.0.len(), 3, "Parent should receive AutoDefault (auto_propagate)");
+    assert_eq!(
+        parent_log.0.len(),
+        3,
+        "Parent should receive AutoDefault (auto_propagate)"
+    );
     assert_eq!(parent_log.0[2], "parent_auto_def_30");
 
     // === Test Variant D: ManualCustom ===
     // Override: manual propagate + MountOf (custom relationship)
-    app.world_mut().trigger(enum_level_propagate_event::ManualCustom {
-        entity: mount,
-        value: 40,
-    });
+    app.world_mut()
+        .trigger(enum_level_propagate_event::ManualCustom {
+            entity: mount,
+            value: 40,
+        });
     app.update();
 
     let mount_log = app.world().get::<DamageLog>(mount).unwrap();
@@ -898,15 +984,20 @@ fn test_scenario2_enum_propagation_with_variant_overrides() {
     assert_eq!(mount_log.0[0], "mount_manual_custom_40");
 
     let rider_log = app.world().get::<DamageLog>(rider).unwrap();
-    assert_eq!(rider_log.0.len(), 1, "Rider should receive ManualCustom (manual propagate with MountOf)");
+    assert_eq!(
+        rider_log.0.len(),
+        1,
+        "Rider should receive ManualCustom (manual propagate with MountOf)"
+    );
     assert_eq!(rider_log.0[0], "rider_manual_custom_40");
 
     // === Test Variant E: AutoCustom ===
     // Override: auto_propagate + MountOf (custom relationship)
-    app.world_mut().trigger(enum_level_propagate_event::AutoCustom {
-        entity: mount,
-        value: 50,
-    });
+    app.world_mut()
+        .trigger(enum_level_propagate_event::AutoCustom {
+            entity: mount,
+            value: 50,
+        });
     app.update();
 
     let mount_log = app.world().get::<DamageLog>(mount).unwrap();
@@ -914,6 +1005,10 @@ fn test_scenario2_enum_propagation_with_variant_overrides() {
     assert_eq!(mount_log.0[1], "mount_auto_custom_50");
 
     let rider_log = app.world().get::<DamageLog>(rider).unwrap();
-    assert_eq!(rider_log.0.len(), 2, "Rider should receive AutoCustom (auto_propagate with MountOf)");
+    assert_eq!(
+        rider_log.0.len(),
+        2,
+        "Rider should receive AutoCustom (auto_propagate with MountOf)"
+    );
     assert_eq!(rider_log.0[1], "rider_auto_custom_50");
 }

--- a/tests/variant_propagate.rs
+++ b/tests/variant_propagate.rs
@@ -24,15 +24,21 @@ fn test_enum_level_propagate() {
 #[allow(dead_code)]
 enum MixedPropagateEvent {
     // Uses enum-level propagate
-    Normal { entity: Entity },
+    Normal {
+        entity: Entity,
+    },
 
     // Overrides with auto_propagate
     #[enum_event(auto_propagate, propagate)]
-    Auto { entity: Entity },
+    Auto {
+        entity: Entity,
+    },
 
     // Overrides with custom relationship
     #[enum_event(propagate = &'static ::bevy::prelude::ChildOf)]
-    Custom { entity: Entity },
+    Custom {
+        entity: Entity,
+    },
 }
 
 #[test]
@@ -48,15 +54,21 @@ fn test_variant_level_override() {
 #[allow(dead_code)]
 enum VariantOnlyPropagateEvent {
     // No propagate
-    None { entity: Entity },
+    None {
+        entity: Entity,
+    },
 
     // Has propagate
     #[enum_event(propagate)]
-    Manual { entity: Entity },
+    Manual {
+        entity: Entity,
+    },
 
     // Has auto_propagate with custom relationship
     #[enum_event(auto_propagate, propagate = &'static ::bevy::prelude::ChildOf)]
-    Auto { entity: Entity },
+    Auto {
+        entity: Entity,
+    },
 }
 
 #[test]
@@ -74,15 +86,21 @@ fn test_variant_only_propagate() {
 #[allow(dead_code)]
 enum AutoPropagateOverrideEvent {
     // Inherits: auto_propagate, propagate
-    InheritAuto { entity: Entity },
+    InheritAuto {
+        entity: Entity,
+    },
 
     // Override: removes auto_propagate, uses custom relation
     #[enum_event(propagate = &'static ::bevy::prelude::ChildOf)]
-    NoAutoCustomRel { entity: Entity },
+    NoAutoCustomRel {
+        entity: Entity,
+    },
 
     // Override: keeps auto_propagate, uses custom relation
     #[enum_event(auto_propagate, propagate = &'static ::bevy::prelude::ChildOf)]
-    WithAutoCustomRel { entity: Entity },
+    WithAutoCustomRel {
+        entity: Entity,
+    },
 }
 
 #[test]


### PR DESCRIPTION
- Update Bevy dependency from 0.17 to 0.18
- Bump crate version to 0.3.0
- Clean up and simplify documentation
- Format code with rustfmt