### PR TITLE
Update to version v0.3.2 and rename events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.2] - 2026-01-20
+
+### Changed
+- Renamed `EnumEvent` to `EnumMessage` to align with Bevy 0.17+ nomenclature (Event → Message)
+- `EnumEntityEvent` remains unchanged
+
 ## [0.3.0] - 2026-01-20
 
 ### Changed
@@ -22,7 +28,7 @@
 ## [0.1.0] - 2025-10-20
 
 ### Added
-- `EnumEvent` derive macro for global events
+- `EnumMessage` derive macro for global messages (originally named `EnumEvent`)
 - Support for unit, tuple, and named field variants
 - `deref` feature (default) for ergonomic field access
 - Full support for generics and lifetimes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_enum_event"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "bevy",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "bevy_enum_event"
-version = "0.3.0"
+version = "0.3.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-description = "General-purpose enum to Bevy event conversion macro - generates Event and EntityEvent types from enum variants with support for entity targeting and propagation"
+description = "General-purpose enum to Bevy message conversion macro - generates Message and EntityEvent types from enum variants with support for entity targeting and propagation"
 repository = "https://github.com/ffmulks/bevy_enum_event"
 authors = ["Dr. Florian Mulks <dr@mulks.ac>"]
-keywords = ["bevy", "enum", "events", "macro"]
+keywords = ["bevy", "enum", "events", "messages", "macro"]
 categories = ["game-development"]
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # bevy_enum_event
 
-Derive macros that generate Bevy event types from enum variants.
+Derive macros that generate Bevy message types from enum variants.
 
 ## Overview
 
-Transform enum variants into distinct Bevy event structs automatically. Each variant becomes a separate event type in a snake_case module, eliminating boilerplate while preserving type safety.
+Transform enum variants into distinct Bevy message structs automatically. Each variant becomes a separate message type in a snake_case module, eliminating boilerplate while preserving type safety.
 
 ```rust
 use bevy::prelude::*;
-use bevy_enum_event::EnumEvent;
+use bevy_enum_event::EnumMessage;
 
-#[derive(EnumEvent, Clone)]
+#[derive(EnumMessage, Clone)]
 enum GameEvent {
     Victory(String),
     ScoreChanged { team: u32, score: i32 },
@@ -24,7 +24,7 @@ enum GameEvent {
 
 | Bevy | bevy_enum_event |
 |------|-----------------|
-| 0.18 | 0.3             |
+| 0.18 | 0.3.2           |
 | 0.17 | 0.2             |
 | 0.16 | 0.1             |
 
@@ -32,22 +32,22 @@ enum GameEvent {
 
 ```toml
 [dependencies]
-bevy_enum_event = "0.3"
+bevy_enum_event = "0.3.2"
 ```
 
 ## Macros
 
-- **`EnumEvent`** - Generates global `Event` types
+- **`EnumMessage`** - Generates global `Message` types
 - **`EnumEntityEvent`** - Generates entity-targeted `EntityEvent` types with optional propagation
 
-## EnumEvent
+## EnumMessage
 
 Supports unit, tuple, and named field variants:
 
 ```rust
-use bevy_enum_event::EnumEvent;
+use bevy_enum_event::EnumMessage;
 
-#[derive(EnumEvent, Clone)]
+#[derive(EnumMessage, Clone)]
 enum PlayerState {
     Idle,                           // Unit variant
     Moving(f32),                    // Tuple variant
@@ -72,7 +72,7 @@ fn on_attacking(event: On<player_state::Attacking>) {
 Single-field variants automatically implement `Deref`/`DerefMut`:
 
 ```rust
-#[derive(EnumEvent, Clone)]
+#[derive(EnumMessage, Clone)]
 enum NetworkEvent {
     MessageReceived(String),  // Automatic deref to String
 }
@@ -85,7 +85,7 @@ fn on_message(msg: On<network_event::MessageReceived>) {
 For multi-field variants, mark one field with `#[enum_event(deref)]`:
 
 ```rust
-#[derive(EnumEvent, Clone)]
+#[derive(EnumMessage, Clone)]
 enum GameEvent {
     PlayerScored {
         #[enum_event(deref)]
@@ -193,7 +193,7 @@ enum MixedEvent {
 Full support for generic parameters and lifetimes:
 
 ```rust
-#[derive(EnumEvent, Clone)]
+#[derive(EnumMessage, Clone)]
 enum GenericEvent<'a, T>
 where
     T: Clone + 'a,

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -7,10 +7,10 @@
 //! - Mixed variants in a single enum
 //! - Deref behavior for single-field variants
 
-use bevy_enum_event::EnumEvent;
+use bevy_enum_event::EnumMessage;
 
 // Example 1: Unit variants only (e.g., simple state machine)
-#[derive(EnumEvent, Clone, Copy, Debug)]
+#[derive(EnumMessage, Clone, Copy, Debug)]
 #[allow(dead_code)]
 pub enum PlayerState {
     Idle,
@@ -19,7 +19,7 @@ pub enum PlayerState {
 }
 
 // Example 2: Mixed variants with data (realistic game events)
-#[derive(EnumEvent, Clone, Debug)]
+#[derive(EnumMessage, Clone, Debug)]
 #[allow(dead_code)]
 pub enum GameEvent {
     /// A player wins with their team name
@@ -31,7 +31,7 @@ pub enum GameEvent {
 }
 
 // Example 3: Single-field variants (benefit from deref feature)
-#[derive(EnumEvent, Clone, Debug)]
+#[derive(EnumMessage, Clone, Debug)]
 #[allow(dead_code)]
 pub enum NetworkEvent {
     MessageReceived(String),

--- a/tests/derive_enum_events.rs
+++ b/tests/derive_enum_events.rs
@@ -1,8 +1,8 @@
 use bevy::prelude::Entity;
-use bevy_enum_event::{EnumEntityEvent, EnumEvent};
+use bevy_enum_event::{EnumEntityEvent, EnumMessage};
 
 // Test unit variants
-#[derive(EnumEvent, Clone, Copy, Debug, PartialEq)]
+#[derive(EnumMessage, Clone, Copy, Debug, PartialEq)]
 #[allow(dead_code)]
 enum UnitEnum {
     A,
@@ -23,7 +23,7 @@ fn test_unit_variants() {
 }
 
 // Test tuple variants
-#[derive(EnumEvent, Clone, Debug)]
+#[derive(EnumMessage, Clone, Debug)]
 #[allow(dead_code)]
 enum TupleEnum {
     Single(u32),
@@ -46,7 +46,7 @@ fn test_tuple_variants() {
 }
 
 // Test named field variants
-#[derive(EnumEvent, Clone, Debug)]
+#[derive(EnumMessage, Clone, Debug)]
 #[allow(dead_code)]
 enum NamedEnum {
     SingleField { value: u32 },
@@ -72,7 +72,7 @@ fn test_named_field_variants() {
 }
 
 // Test mixed variants
-#[derive(EnumEvent, Clone, Debug)]
+#[derive(EnumMessage, Clone, Debug)]
 #[allow(dead_code)]
 enum MixedEnum {
     Unit,
@@ -96,7 +96,7 @@ fn test_mixed_variants() {
 #[cfg(feature = "deref")]
 #[test]
 fn test_deref_tuple_variant() {
-    #[derive(EnumEvent, Clone)]
+    #[derive(EnumMessage, Clone)]
     #[allow(dead_code)]
     enum DerefTuple {
         Value(String),
@@ -118,7 +118,7 @@ fn test_deref_tuple_variant() {
 #[cfg(feature = "deref")]
 #[test]
 fn test_deref_named_variant() {
-    #[derive(EnumEvent, Clone)]
+    #[derive(EnumMessage, Clone)]
     #[allow(dead_code)]
     enum DerefNamed {
         Value { data: String },
@@ -141,7 +141,7 @@ fn test_deref_named_variant() {
 // Test that multi-field variants don't have deref
 #[test]
 fn test_multi_field_variants() {
-    #[derive(EnumEvent, Clone)]
+    #[derive(EnumMessage, Clone)]
     #[allow(dead_code)]
     enum MultiField {
         Multiple(String, i32),
@@ -164,7 +164,7 @@ fn test_multi_field_variants() {
 #[cfg(feature = "deref")]
 #[test]
 fn test_multi_field_deref_with_attribute() {
-    #[derive(EnumEvent, Clone)]
+    #[derive(EnumMessage, Clone)]
     #[allow(dead_code)]
     enum MultiFieldDeref {
         Tuple(#[enum_event(deref)] String, i32),
@@ -199,7 +199,7 @@ fn test_multi_field_deref_with_attribute() {
 // Test Clone trait
 #[test]
 fn test_clone() {
-    #[derive(EnumEvent, Clone)]
+    #[derive(EnumMessage, Clone)]
     #[allow(dead_code)]
     enum CloneEnum {
         Value(String),
@@ -213,7 +213,7 @@ fn test_clone() {
 // Test Debug trait
 #[test]
 fn test_debug() {
-    #[derive(EnumEvent, Clone, Debug)]
+    #[derive(EnumMessage, Clone, Debug)]
     #[allow(dead_code)]
     enum DebugEnum {
         Value(String),
@@ -226,7 +226,7 @@ fn test_debug() {
 
 #[test]
 fn test_generic_enum_support() {
-    #[derive(EnumEvent, Clone, Debug)]
+    #[derive(EnumMessage, Clone, Debug)]
     #[allow(dead_code)]
     enum GenericEnum<T>
     where
@@ -237,7 +237,7 @@ fn test_generic_enum_support() {
         Unit,
     }
 
-    #[derive(EnumEvent, Clone, Copy, Debug)]
+    #[derive(EnumMessage, Clone, Copy, Debug)]
     #[allow(dead_code)]
     enum BorrowedEnum<'event> {
         Reference(&'event i32),


### PR DESCRIPTION
- Renamed `EnumEvent` derive macro to `EnumMessage` to align with Bevy's Event → Message naming convention introduced in Bevy 0.17
- Updated version to 0.3.2
- Updated all documentation, examples, and tests to use the new name
- `EnumEntityEvent` remains unchanged as entity events keep the same name
- Generated code still uses Bevy's `Event` trait internally